### PR TITLE
Bugfix - Merge Commits

### DIFF
--- a/samsgeneratechangelog/githelper.py
+++ b/samsgeneratechangelog/githelper.py
@@ -109,6 +109,9 @@ class GitHelper:
             '--pretty=%H', f"{rev_a}...{rev_b}").split('\n')
         for commit_id in commit_ids:
             commit = self.repo.commit(commit_id)
+            if len(commit.parents) > 1:
+                # Skip merge commits
+                continue
             for file_commit in self.generate_file_commits_from_commit(commit):
                 yield file_commit
 

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open(path.join(this_directory, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 setup(
-    version='1.0.2',
+    version='1.0.3',
     python_requires='>=3.6.0',
     name='samsgeneratechangelog',
     packages=['samsgeneratechangelog'],

--- a/tests/test_git_helper.py
+++ b/tests/test_git_helper.py
@@ -1,0 +1,18 @@
+import os
+import unittest
+from samsgeneratechangelog import GitHelper
+
+TEST_FOLDER = os.path.dirname(os.path.realpath(__file__))
+GIT_FOLDER = os.path.join(TEST_FOLDER, '..')
+
+
+class TestGitHelper(unittest.TestCase):
+
+    def test_commit_log_does_not_return_merge_commits(self):
+        gh = GitHelper(path=GIT_FOLDER)
+        
+        results = list(gh.commit_log(rev_a='1.0.1', rev_b='1.0.2'))
+
+        for commit in results:
+            assert len(commit.commit.parents) == 1
+

--- a/tests/test_git_helper.py
+++ b/tests/test_git_helper.py
@@ -10,9 +10,8 @@ class TestGitHelper(unittest.TestCase):
 
     def test_commit_log_does_not_return_merge_commits(self):
         gh = GitHelper(path=GIT_FOLDER)
-        
+
         results = list(gh.commit_log(rev_a='1.0.1', rev_b='1.0.2'))
 
         for commit in results:
             assert len(commit.commit.parents) == 1
-


### PR DESCRIPTION
Merge commits were being included in the return from `GitHelper.commit_log` as FileCommit objects, which caused a random parent of the merge commit to be chosen for the diff of that commit. This meant that files which were not actually part of the diff between `start_ref` and `end_ref` could erroneously appear as changed.